### PR TITLE
Fix tree hash tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '~1.9.0-'
+          - '~1.9.0-0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         version:
           - '1.6'
           - '1'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '1.9'
+          - '~1.9.0-'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
+          show-versioninfo: true
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: actions/cache@v1

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.1-dev"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ julia> recorded_modules()
 Set{Module} with 9 elements:
   JLD2
   Compat
-  OrderedCollections
   TranscodingStreams
   PackageStates
   Requires
@@ -82,17 +81,19 @@ The central function to inquire about the state of a package is `state`, which r
 julia> state(JLD2)
 
 PackageState of JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]
-┌───────────────┬────────────────────────────────────────────────────────────────────────────────────┐
-│     Timestamp │ 2021-09-26 21:42                                                                   │
-│     Load path │ ["/tmp/path/to/env_old/Project.toml",                                              │
-│               │ "/Users/philip/.julia/environments/v1.6/Project.toml",                             │
-│               │ "/Applications/Julia-1.6.app/Contents/Resources/julia/share/julia/stdlib/v1.6"]    │
-│    Package ID │ JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]                                        │
-│   Source path │ /Users/philip/.julia/packages/JLD2/VHRWL                                           │
-│     Tree hash │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                           │
-│ Manifest t.h. │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                           │
-│       Project │ /tmp/path/to/env_old/Project.toml                                                  │
-└───────────────┴────────────────────────────────────────────────────────────────────────────────────┘
+┌────────────────┬──────────────────────────────────────────────────────────────────────────────────────┐
+│      Timestamp │ 2023-02-07 09:41                                                                     │
+│      Load path │ ["/tmp/path/to/env_old/Project.toml",                                                │
+│                │ "/Users/philip/.julia/environments/v1.8/Project.toml",                               │
+│                │ "/Users/philip/.julia/juliaup/julia-1.8.5+0.x64.apple.darwin14/share/julia/stdlib/v1 │
+│                │ .8"]                                                                                 │
+│     Package ID │ JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]                                          │
+│    Source path │ /Users/philip/.julia/packages/JLD2/VHRWL                                             │
+│ Head tree hash │ missing                                                                              │
+│ Directory t.h. │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                             │
+│  Manifest t.h. │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                             │
+│        Project │ /tmp/path/to/env_old/Project.toml                                                    │
+└────────────────┴──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 By default, `state` returns the current state, not a state recorded in the past, so the time stamp will be the current time. The `PackageState` returned by it includes a number of things:
 
@@ -114,17 +115,19 @@ julia> Pkg.activate("/tmp/path/to/env_new")
 julia> state(JLD2)
 
 PackageState of JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]
-┌───────────────┬────────────────────────────────────────────────────────────────────────────────────┐
-│     Timestamp │ 2021-09-26 21:44                                                                   │
-│     Load path │ ["/tmp/path/to/env_new/Project.toml",                                              │
-│               │ "/Users/philip/.julia/environments/v1.6/Project.toml",                             │
-│               │ "/Applications/Julia-1.6.app/Contents/Resources/julia/share/julia/stdlib/v1.6"]    │
-│    Package ID │ JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]                                        │
-│   Source path │ /Users/philip/.julia/packages/JLD2/VHRWL                                           │
-│     Tree hash │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                           │
-│ Manifest t.h. │ 192934b3e2a94e897ce177423fd6cf7bdf464bce                                           │
-│       Project │ /tmp/path/to/env_new/Project.toml                                                  │
-└───────────────┴────────────────────────────────────────────────────────────────────────────────────┘
+┌────────────────┬──────────────────────────────────────────────────────────────────────────────────────┐
+│      Timestamp │ 2023-02-07 09:42                                                                     │
+│      Load path │ ["/tmp/path/to/env_new/Project.toml",                                                │
+│                │ "/Users/philip/.julia/environments/v1.8/Project.toml",                               │
+│                │ "/Users/philip/.julia/juliaup/julia-1.8.5+0.x64.apple.darwin14/share/julia/stdlib/v1 │
+│                │ .8"]                                                                                 │
+│     Package ID │ JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]                                          │
+│    Source path │ /Users/philip/.julia/packages/JLD2/VHRWL                                             │
+│ Head tree hash │ missing                                                                              │
+│ Directory t.h. │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                             │
+│  Manifest t.h. │ c3244ef42b7d4508c638339df1bdbf4353e144db                                             │
+│        Project │ /tmp/path/to/env_new/Project.toml                                                    │
+└────────────────┴──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 The Manifest tree hash changed since this environment (indicated by "Project") now requests a different version of JLD2. The first tree hash is still the same as it corresponds to the loaded source (whose path did not change, either). However, the tree hash can in principle change as well if the any of the source files change (for example, for a package in its own environment or for a dev'ed package). Since `state` always returns the current state by default, the project and load path now reflect the current environment. We can access the state recorded on load by requesting it explicitly:
 
@@ -132,17 +135,19 @@ The Manifest tree hash changed since this environment (indicated by "Project") n
 julia> state(JLD2, :on_load)
 
 PackageState of JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]
-┌───────────────┬────────────────────────────────────────────────────────────────────────────────────┐
-│     Timestamp │ 2021-09-26 21:40                                                                   │
-│     Load path │ ["/tmp/path/to/env_old/Project.toml",                                              │
-│               │ "/Users/philip/.julia/environments/v1.6/Project.toml",                             │
-│               │ "/Applications/Julia-1.6.app/Contents/Resources/julia/share/julia/stdlib/v1.6"]    │
-│    Package ID │ JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]                                        │
-│   Source path │ /Users/philip/.julia/packages/JLD2/VHRWL                                           │
-│     Tree hash │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                           │
-│ Manifest t.h. │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                           │
-│       Project │ /tmp/path/to/env_old/Project.toml                                                  │
-└───────────────┴────────────────────────────────────────────────────────────────────────────────────┘
+┌────────────────┬──────────────────────────────────────────────────────────────────────────────────────┐
+│      Timestamp │ 2023-02-07 09:33                                                                     │
+│      Load path │ ["/tmp/path/to/env_old/Project.toml",                                                │
+│                │ "/Users/philip/.julia/environments/v1.8/Project.toml",                               │
+│                │ "/Users/philip/.julia/juliaup/julia-1.8.5+0.x64.apple.darwin14/share/julia/stdlib/v1 │
+│                │ .8"]                                                                                 │
+│     Package ID │ JLD2 [033835bb-8acc-5ee8-8aae-3f567f8a3819]                                          │
+│    Source path │ /Users/philip/.julia/packages/JLD2/VHRWL                                             │
+│ Head tree hash │ missing                                                                              │
+│ Directory t.h. │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                             │
+│  Manifest t.h. │ 59ee430ac5dc87bc3eec833cc2a37853425750b4                                             │
+│        Project │ /tmp/path/to/env_old/Project.toml                                                    │
+└────────────────┴──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 This way, we can find out in retrospect in what environment which version of a package was loaded. Other possibilities are `:current` (the default) and `:newest` which corresponds to the newest recorded state, or an integer index refering to the states in the order they were recorded. Currently, the only automatic recording happens at load time of a package, so unless recording is triggered manually (see State diffing below), the two will be identical.
 
@@ -154,17 +159,19 @@ julia> using Requires
 julia> state(Requires)
 
 PackageState of Requires [ae029012-a4dd-5104-9daa-d747884805df]
-┌───────────────┬────────────────────────────────────────────────────────────────────────────────────┐
-│     Timestamp │ 2021-09-26 21:45                                                                   │
-│     Load path │ ["/tmp/path/to/env_new/Project.toml",                                              │
-│               │ "/Users/philip/.julia/environments/v1.6/Project.toml",                             │
-│               │ "/Applications/Julia-1.6.app/Contents/Resources/julia/share/julia/stdlib/v1.6"]    │
-│    Package ID │ Requires [ae029012-a4dd-5104-9daa-d747884805df]                                    │
-│   Source path │ /Users/philip/.julia/packages/Requires/035xH                                       │
-│     Tree hash │ cfbac6c1ed70c002ec6361e7fd334f02820d6419                                           │
-│ Manifest t.h. │ 4036a3bd08ac7e968e27c203d45f5fff15020621                                           │
-│       Project │ /tmp/path/to/env_new/Project.toml                                                  │
-└───────────────┴────────────────────────────────────────────────────────────────────────────────────┘
+┌────────────────┬──────────────────────────────────────────────────────────────────────────────────────┐
+│      Timestamp │ 2023-02-07 09:43                                                                     │
+│      Load path │ ["/tmp/path/to/env_new/Project.toml",                                                │
+│                │ "/Users/philip/.julia/environments/v1.8/Project.toml",                               │
+│                │ "/Users/philip/.julia/juliaup/julia-1.8.5+0.x64.apple.darwin14/share/julia/stdlib/v1 │
+│                │ .8"]                                                                                 │
+│     Package ID │ Requires [ae029012-a4dd-5104-9daa-d747884805df]                                      │
+│    Source path │ /Users/philip/.julia/packages/Requires/035xH                                         │
+│ Head tree hash │ missing                                                                              │
+│ Directory t.h. │ cfbac6c1ed70c002ec6361e7fd334f02820d6419                                             │
+│  Manifest t.h. │ 838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7                                             │
+│        Project │ /tmp/path/to/env_new/Project.toml                                                    │
+└────────────────┴──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 Why? It could be because the source was modified, but let's find out:
@@ -173,17 +180,19 @@ Why? It could be because the source was modified, but let's find out:
 julia> state(Requires, :on_load)
 
 PackageState of Requires [ae029012-a4dd-5104-9daa-d747884805df]
-┌───────────────┬────────────────────────────────────────────────────────────────────────────────────┐
-│     Timestamp │ 2021-09-26 21:40                                                                   │
-│     Load path │ ["/tmp/path/to/env_old/Project.toml",                                              │
-│               │ "/Users/philip/.julia/environments/v1.6/Project.toml",                             │
-│               │ "/Applications/Julia-1.6.app/Contents/Resources/julia/share/julia/stdlib/v1.6"]    │
-│    Package ID │ Requires [ae029012-a4dd-5104-9daa-d747884805df]                                    │
-│   Source path │ /Users/philip/.julia/packages/Requires/035xH                                       │
-│     Tree hash │ cfbac6c1ed70c002ec6361e7fd334f02820d6419                                           │
-│ Manifest t.h. │ cfbac6c1ed70c002ec6361e7fd334f02820d6419                                           │
-│       Project │ /tmp/path/to/env_old/Project.toml                                                  │
-└───────────────┴────────────────────────────────────────────────────────────────────────────────────┘
+┌────────────────┬──────────────────────────────────────────────────────────────────────────────────────┐
+│      Timestamp │ 2023-02-07 09:33                                                                     │
+│      Load path │ ["/tmp/path/to/env_old/Project.toml",                                                │
+│                │ "/Users/philip/.julia/environments/v1.8/Project.toml",                               │
+│                │ "/Users/philip/.julia/juliaup/julia-1.8.5+0.x64.apple.darwin14/share/julia/stdlib/v1 │
+│                │ .8"]                                                                                 │
+│     Package ID │ Requires [ae029012-a4dd-5104-9daa-d747884805df]                                      │
+│    Source path │ /Users/philip/.julia/packages/Requires/035xH                                         │
+│ Head tree hash │ missing                                                                              │
+│ Directory t.h. │ cfbac6c1ed70c002ec6361e7fd334f02820d6419                                             │
+│  Manifest t.h. │ cfbac6c1ed70c002ec6361e7fd334f02820d6419                                             │
+│        Project │ /tmp/path/to/env_old/Project.toml                                                    │
+└────────────────┴──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 We see that the source was not modified, but that this version was loaded in the `env_old` environment (as a dependency of JLD2), where it corresponded exactly to the requested version.
@@ -191,7 +200,9 @@ We see that the source was not modified, but that this version was loaded in the
 ## State diffing
 Besides `recorded_modules` and `state`, there are convenience functions to compare states:
 
-<img width="1184" alt="Screenshot 2021-09-26 at 21 48 00" src="https://user-images.githubusercontent.com/8332598/134892722-bced432c-57c3-482b-b009-c6c0b15d0491.png">
+<img width="1224" alt="image" src="https://user-images.githubusercontent.com/8332598/217195698-9713cde4-887c-450b-b38f-4f25e226c26a.png">
+
+
 
 
 Similar to git diff, `diff_states` by default compares the `:newest` recorded state to the `:current` state. It returns a Boolean indicating whether the states differ and prints a pretty table with changes marked in red if they do. Printing can be disabled by passing `print = false`. The versions to compare can be specified as a pair:
@@ -202,7 +213,7 @@ false
 ```
 As mentioned above, the only automatic recording happens at load time of a package, so `:on_load` and `:newest` are still identical at this point. However, we can trigger recording of a state manually by passing `update = true`, provided we are comparing to the newest recorded to the current version (as is the default):
 
-<img width="1180" alt="Screenshot 2021-09-26 at 21 49 33" src="https://user-images.githubusercontent.com/8332598/134892906-9582f9ea-2ce0-4e4e-b785-b8a2dc5e3e86.png">
+<img width="1224" alt="image" src="https://user-images.githubusercontent.com/8332598/217195921-c407e102-0e30-4ddf-b2ac-b5b8812941a5.png">
 
 
 Note that calling `diff_states` a second time returns `false` (no matter whether `update` is passed or not) as the newest recorded state is now identical to the current one. Comparing to the :on_load version instead can be done via `diff_states(JLD2, :on_load => :current)`.

--- a/src/PackageStates.jl
+++ b/src/PackageStates.jl
@@ -3,6 +3,7 @@ module PackageStates
 using Pkg
 using Dates
 using PrettyTables
+using LibGit2
 
 include("utils.jl")
 include("core.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -4,8 +4,9 @@ Base.@kwdef struct PackageState
     load_path::Vector{String}
     id::Base.PkgId
     dir::String
-    tree_hash::String
-    manifest_tree_hash::Union{Nothing,String}
+    head_tree_hash::String
+    directory_tree_hash::String
+    manifest_tree_hash::String
     project::Union{Nothing,String}
 end
 
@@ -14,7 +15,8 @@ function Base.:(==)(s1::PackageState, s2::PackageState)
     s1.id == s2.id &&
     s1.project == s2.project &&
     s1.load_path == s2.load_path &&
-    s1.tree_hash == s2.tree_hash &&
+    s1.head_tree_hash == s2.head_tree_hash &&
+    s1.directory_tree_hash == s2.directory_tree_hash &&
     s1.manifest_tree_hash == s2.manifest_tree_hash
 end
 
@@ -22,7 +24,8 @@ const row_names = ["Timestamp",
                    "Load path",
                    "Package ID",
                    "Source path",
-                   "Tree hash",
+                   "Head tree hash",
+                   "Directory t.h.",
                    "Manifest t.h.",
                    "Project"]
 
@@ -31,7 +34,8 @@ function tabledata(s::PackageState)
             s.load_path,
             s.id,
             s.dir,
-            s.tree_hash,
+            s.head_tree_hash,
+            s.directory_tree_hash,
             s.manifest_tree_hash,
             s.project]
     return data
@@ -63,7 +67,8 @@ function current_package_state(pkg::Base.PkgId)
     #println("Path: ", pathof(m))
     #println("pkgdir: ", pkgdir(m))
     d = pkgdir(m)
-    th = tree_hash_fmt(d)
+    hth = tree_hash_fmt_head(d)
+    dth = tree_hash_fmt_dir(d)
     project, mth = project_and_tree_hash(pkg)
     return PackageState(
             timestamp = date,
@@ -71,7 +76,8 @@ function current_package_state(pkg::Base.PkgId)
             id = pkg,
             project = project,
             load_path = Base.load_path(),
-            tree_hash = th,
+            head_tree_hash = hth,
+            directory_tree_hash = dth,
             manifest_tree_hash = mth)
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -53,7 +53,7 @@ function printtable(datavectors::Vararg{AbstractVector, N}; kwargs...) where N
                  row_names = row_names,
                  autowrap = true,
                  linebreaks = true,
-                 columns_width = min((displaysize(stdout)[2]-18-3*N)÷N,100*N),
+                 columns_width = min((displaysize(stdout)[2]-19-3*N)÷N,100*N),
                  alignment = :l,
                  noheader = N == 1,
                  highlighters = highlighters; kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,59 @@
-tree_hash_fmt(d) = bytes2hex(Pkg.GitTools.tree_hash(d))
 
-EMPTY_TREE_HASH = "none (package dev'ed)"
+function tree_hash_fmt_dir(d)
+    
+    if !Sys.iswindows()
+        return bytes2hex(Pkg.GitTools.tree_hash(d))
+    end
+
+
+    # The simple approach above yields a different tree hash on Windows, even if the directory is
+    # a clean working copy of the repo
+    # Same reason because of which this thing is in Pkg.jl/src/Operations.jl:
+        # # Assert that the tarball unpacked to the tree sha we wanted
+        # # TODO: Enable on Windows when tree_hash handles
+        # # executable bits correctly, see JuliaLang/julia #33212.
+        # if !Sys.iswindows()
+        #     if SHA1(GitTools.tree_hash(unpacked)) != hash
+        #         @warn "tarball content does not match git-tree-sha1"
+        #         url_success = false
+        #     end
+        #     url_success || continue
+        # end
+
+
+    # Workaround for windows: copy the directory, create git repo, write-tree
+    hash = mktempdir() do tmpdir
+        repodir = joinpath(tmpdir, splitpath(realpath(d))[end])
+        # If directory is a symlink, copying it would actually link to the same directory
+        # modifying the target -> abort
+        if islink(d)
+            @warn("$(d): path is a symlink, not calculating tree hash")
+            return EMPTY_TREE_HASH
+        end
+
+        cp(d, repodir)
+        if !isdir(joinpath(repodir, ".git"))
+            r = LibGit2.init(repodir)
+        else
+            r = LibGit2.GitRepo(repodir)
+        end
+        gi = LibGit2.GitIndex(r)
+        LibGit2.add!(gi, "**"; flags = LibGit2.Consts.INDEX_ADD_FORCE)
+        return string(LibGit2.write_tree!(gi))
+    end
+    return hash
+end
+
+
+function tree_hash_fmt_head(d)
+    isdir(joinpath(d, ".git")) || return EMPTY_TREE_HASH
+    commit = Pkg.Types.get_object_or_branch(LibGit2.GitRepo(d), "HEAD")[1]
+    tree = LibGit2.peel(LibGit2.GitTree, commit)
+    hash = LibGit2.GitHash(tree)
+    return string(hash)
+end
+
+EMPTY_TREE_HASH = "missing"
 
 function project_and_tree_hash(pkg::Base.PkgId)
     for env in Base.load_path()
@@ -9,7 +62,7 @@ function project_and_tree_hash(pkg::Base.PkgId)
         mth = explicit_manifest_uuid_path_tree_hash(project_file,pkg)
         mth === nothing || return env, mth
     end
-    return nothing, nothing
+    return nothing, EMPTY_TREE_HASH
 end
 
 # Analogous to explicit_manifest_uuid_path from base/loading.jl,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 
-function tree_hash_fmt_dir(d)
+function tree_hash_fmt_dir(d; use_dir = !Sys.iswindows())
     
-    if !Sys.iswindows()
+    if use_dir
         return bytes2hex(Pkg.GitTools.tree_hash(d))
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,6 +120,11 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
             @test PackageStates.tree_hash_fmt_dir(dummy; use_dir = false) == PackageStates.tree_hash_fmt_dir(s.dir; use_dir = true)
         end
 
+        # Test that the heavy method of copying and creating a repo for the tree hash is skipped on symlinks
+        symlink(dummy, joinpath(tmp, "link"))
+        @test PackageStates.tree_hash_fmt_dir(joinpath(tmp, "link"); use_dir = false) == PackageStates.EMPTY_TREE_HASH
+        @test startswith(@capture_err(PackageStates.tree_hash_fmt_dir(joinpath(tmp, "link"); use_dir = false)), "┌ Warning: ")
+
         @test recorded_modules() == Set([AnotherDummyPackage, DummyPackage, PackageStates])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,8 +28,9 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         dummy = mkdummypackage(tmp, "DummyPackage")
         dummy2 = mkdummypackage(tmp, "DummyPackage_v2")
         
-        # Julia on Windows used to compute a different tree hash
-        th1 = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" : "dd574217160ae714ff496b9239a5ae1a4d819aa8"
+        # Julia on Windows computes a different tree hash
+        th1 = Sys.iswindows() ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" : "dd574217160ae714ff496b9239a5ae1a4d819aa8"
+        # Whatever that bug is, it doesn't seem to affect version 2 of the Dummy package...
         th2 = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "90ca0b300186580cfe89f5336ec58453257a1ec6" : "98cea5b18356123cda026692eafb1e4a55813dac"
 
         Pkg.activate(env1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,8 +28,9 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         dummy = mkdummypackage(tmp, "DummyPackage")
         dummy2 = mkdummypackage(tmp, "DummyPackage_v2")
         
-        th1 = Sys.iswindows() ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" : "dd574217160ae714ff496b9239a5ae1a4d819aa8"
-        th2 = Sys.iswindows() ? "90ca0b300186580cfe89f5336ec58453257a1ec6" : "98cea5b18356123cda026692eafb1e4a55813dac"
+        # Julia on Windows used to compute a different tree hash
+        th1 = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" : "dd574217160ae714ff496b9239a5ae1a4d819aa8"
+        th2 = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "90ca0b300186580cfe89f5336ec58453257a1ec6" : "98cea5b18356123cda026692eafb1e4a55813dac"
 
         Pkg.activate(env1)
         Pkg.add(path=dummy)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,9 +30,9 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         anotherdummy = mkdummypackage(tmp, "AnotherDummyPackage")
         
         # Julia on Windows computes a different tree hash
-        th1 = Sys.iswindows() ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" : "dd574217160ae714ff496b9239a5ae1a4d819aa8"
+        th1 = #=Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" :=# "dd574217160ae714ff496b9239a5ae1a4d819aa8"
         # Whatever that bug is, it doesn't seem to affect version 2 of the Dummy package...
-        th2 = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "90ca0b300186580cfe89f5336ec58453257a1ec6" : "98cea5b18356123cda026692eafb1e4a55813dac"
+        th2 = #=Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "90ca0b300186580cfe89f5336ec58453257a1ec6" :=# "98cea5b18356123cda026692eafb1e4a55813dac"
 
         th_another = "cc7028d54f62f514daf4b627ad3b60df47ee018b"
         th_another_mod = "3af98e735356d9fb59ccfda8a3264543dd290e1e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,13 +29,12 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         dummy2 = mkdummypackage(tmp, "DummyPackage_v2")
         anotherdummy = mkdummypackage(tmp, "AnotherDummyPackage")
         
-        # Julia on Windows computes a different tree hash
-        th1 = #=Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" :=# "dd574217160ae714ff496b9239a5ae1a4d819aa8"
-        # Whatever that bug is, it doesn't seem to affect version 2 of the Dummy package...
-        th2 = #=Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "90ca0b300186580cfe89f5336ec58453257a1ec6" :=# "98cea5b18356123cda026692eafb1e4a55813dac"
+        # Julia on Windows computes a different tree hash before version 1.9.0
+        th1 = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "1bd2b16b793dfbf96aef17385f635729ae32a43c" : "dd574217160ae714ff496b9239a5ae1a4d819aa8"
+        th2 = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "90ca0b300186580cfe89f5336ec58453257a1ec6" : "98cea5b18356123cda026692eafb1e4a55813dac"
 
-        th_another = "cc7028d54f62f514daf4b627ad3b60df47ee018b"
-        th_another_mod = "3af98e735356d9fb59ccfda8a3264543dd290e1e"
+        th_another = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "eb224df14392b1d2e12f969907b6404cbd7ab543" : "cc7028d54f62f514daf4b627ad3b60df47ee018b"
+        th_another_mod = Sys.iswindows() && Base.VERSION < v"1.9.0-" ? "a43d3ea9c1d3f6804e709691a4d4317cac3ce5f9" : "3af98e735356d9fb59ccfda8a3264543dd290e1e"
 
         Pkg.activate(env1)
         Pkg.add(path=dummy)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,7 +112,13 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         # This test to detect if it ever changes (then the heavy use_dir=false
         # branch could be removed from tree_hash_fmt_dir).
         th_dir_broken = Sys.iswindows() && !th_broken
-        @test PackageStates.tree_hash_fmt_dir(s.dir; use_dir = false) == PackageStates.tree_hash_fmt_dir(s.dir; use_dir = true) broken=th_dir_broken
+        if th_dir_broken # could use @test ... broken=th_dir_broken here, but doesn't work on Julia 1.6
+            @test PackageStates.tree_hash_fmt_dir(s.dir; use_dir = false) ≠ PackageStates.tree_hash_fmt_dir(s.dir; use_dir = true)
+            @test PackageStates.tree_hash_fmt_dir(dummy; use_dir = false) ≠ PackageStates.tree_hash_fmt_dir(s.dir; use_dir = true)
+        else
+            @test PackageStates.tree_hash_fmt_dir(s.dir; use_dir = false) == PackageStates.tree_hash_fmt_dir(s.dir; use_dir = true)
+            @test PackageStates.tree_hash_fmt_dir(dummy; use_dir = false) == PackageStates.tree_hash_fmt_dir(s.dir; use_dir = true)
+        end
 
         @test recorded_modules() == Set([AnotherDummyPackage, DummyPackage, PackageStates])
     end

--- a/test/test_packages/AnotherDummyPackage/Project.toml
+++ b/test/test_packages/AnotherDummyPackage/Project.toml
@@ -1,0 +1,4 @@
+name = "AnotherDummyPackage"
+uuid = "ec50f1ad-e620-45d3-a112-6d65079ced2f"
+authors = ["Philip Bittihn <philip@bittihn.de>"]
+version = "0.1.0"

--- a/test/test_packages/AnotherDummyPackage/src/AnotherDummyPackage.jl
+++ b/test/test_packages/AnotherDummyPackage/src/AnotherDummyPackage.jl
@@ -1,0 +1,5 @@
+module AnotherDummyPackage
+
+    version() = "v1"
+
+end # module


### PR DESCRIPTION
Julia recently fixed a bug where the tree hash computed on Windows could differ from the one on linux. Our tests accounted for this bug, but it has been fixed recently. This pull request restricts the alternative tree hash expectation to older Julia versions.