### PR TITLE
Compatibility with PrettyTables v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,30 +3,18 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: "Add the General registry via Git"
-        run: |
-          import Pkg
-          ENV["JULIA_PKG_SERVER"] = ""
-          Pkg.Registry.add("General")
-        shell: julia --color=yes {0}
-      - name: "Install CompatHelper"
-        run: |
-          import Pkg
-          name = "CompatHelper"
-          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
-          version = "3"
-          Pkg.add(; name, uuid, version)
-        shell: julia --color=yes {0}
-      - name: "Run CompatHelper"
-        run: |
-          import CompatHelper
-          CompatHelper.main()
-        shell: julia --color=yes {0}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+      - uses: julia-actions/CompatHelper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          compathelper_priv: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -7,6 +7,7 @@ on:
     inputs:
       lookback:
         default: 3
+
 permissions:
   actions: read
   checks: read
@@ -20,13 +21,16 @@ permissions:
   repository-projects: read
   security-events: read
   statuses: read
+
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
-          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,16 @@ on:
     branches:
       - main
     tags: '*'
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -26,36 +32,34 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           show-versioninfo: true
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 #   docs:
 #     name: Documentation
 #     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       pages: write
+#       id-token: write
 #     steps:
-#       - uses: actions/checkout@v2
-#       - uses: julia-actions/setup-julia@v1
+#       - uses: actions/checkout@v4
+#       - uses: julia-actions/setup-julia@v2
 #         with:
 #           version: '1'
+#       - uses: julia-actions/cache@v2
 #       - run: |
 #           julia --project=docs -e '
 #             using Pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         version:
           - '1.10'
+          - '1.11'
           - '1'
           - 'nightly'
         os:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.1-dev
+ - updated version bounds for PrettyTables to include v3
+ - updated PrettyTables API calls to be compatible with v3.x
+ - replaced deprecated parameters: `columns_width` → `fixed_data_column_widths`, `noheader` → `show_column_labels`, `row_names` → `row_labels`, `header` → `column_labels`, `Highlighter` → `TextHighlighter`
+ - note: single-column tables now always show column headers due to PrettyTables v3 limitations
+
 ## v0.2.0
  - now three different tree hashes: head, directory and manifest (see README)
  - (heavy) workaround to compute consistent directory tree hashes on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.2.1-dev
+## v0.2.2
  - updated version bounds for PrettyTables to include v3
  - updated PrettyTables API calls to be compatible with v3.x
  - replaced deprecated parameters: `columns_width` → `fixed_data_column_widths`, `noheader` → `show_column_labels`, `row_names` → `row_labels`, `header` → `column_labels`, `Highlighter` → `TextHighlighter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## v0.2.2
+## v0.2.1
  - updated version bounds for PrettyTables to include v3
  - updated PrettyTables API calls to be compatible with v3.x
  - replaced deprecated parameters: `columns_width` → `fixed_data_column_widths`, `noheader` → `show_column_labels`, `row_names` → `row_labels`, `header` → `column_labels`, `Highlighter` → `TextHighlighter`
  - note: single-column tables now always show column headers due to PrettyTables v3 limitations
+ - updated tests to address changed `__init__` behavior on Julia v1.11 and new world-age semantics for bindings
 
 ## v0.2.0
  - now three different tree hashes: head, directory and manifest (see README)

--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,5 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 
 [compat]
-PrettyTables = "1,2"
+PrettyTables = "1,2,3"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,5 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 
 [compat]
-PrettyTables = "1,2,3"
-julia = "1.6"
+PrettyTables = "3"
+julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "412cc100-f440-45a8-9ec7-153ed5111422"
 license = "MIT"
 desc = "Package version tracking."
 authors = ["Philip Bittihn <philip@bittihn.de>"]
-version = "0.2.2"
+version = "0.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "412cc100-f440-45a8-9ec7-153ed5111422"
 license = "MIT"
 desc = "Package version tracking."
 authors = ["Philip Bittihn <philip@bittihn.de>"]
-version = "0.2.1-dev"
+version = "0.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Set{Module} with 9 elements:
   FileIO
   DataStructures
 ```
-This includes `PackageStates` itself, `JLD2` and `JLD2`s dependencies, excluding anything that was loaded before or by PackageStates. Specifically, stdlibs are always loaded at startup and PackageStates itself has a few dependencies outside stdlibs. If the list on your system contains fewer packages, additional packages with overlapping dependencies were loaded before `using PackageStates` (for example, Revise.jl or similar in your startup.jl). 
+This includes `PackageStates` itself, `JLD2` and `JLD2`s dependencies, excluding anything that was loaded before or by PackageStates (starting with Julia v1.11, `PackageStates`s own dependencies *are* recorded due to changes in Julia internals). Specifically, stdlibs are always loaded at startup and PackageStates itself has a few dependencies outside stdlibs. If the list on your system contains fewer packages, additional packages with overlapping dependencies were loaded before `using PackageStates` (for example, Revise.jl or similar in your startup.jl). 
 
 The central function to inquire about the state of a package is `state`, which returns a `PackageState` that is displayed in the REPL as follows:
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -28,7 +28,7 @@ function diff_states(m::Module, fromto::Pair{T1,T2} = (:newest => :current); pri
 
     differencefound = fromstate ≠ tostate
 
-    differencefound && print && printtable(fromstate, tostate; header = string.([fromto...,]))
+    differencefound && print && printtable(fromstate, tostate; column_labels = string.([fromto...,]))
 
     if update
         fromto !== (:newest => :current) && error("diff_state: update is true but comparing ", fromto, " rather than newest to current state")

--- a/src/core.jl
+++ b/src/core.jl
@@ -56,13 +56,16 @@ function printtable(datavectors::Vararg{AbstractVector, N}; kwargs...) where N
         :auto_wrap => true,
         :line_breaks => true,
         :alignment => :l,
-        :show_column_labels => N != 1,
+        :show_column_labels => true,  # Always show column labels for now
         :highlighters => highlighters
     )
     
-    # Only set fixed column width for multi-column tables with headers
+    # Set column width based on number of columns
     if N > 1
         table_kwargs[:fixed_data_column_widths] = min((displaysize(stdout)[2]-19-3*N)÷N,100*N)
+    else
+        # For single column, let PrettyTables auto-compute the width
+        table_kwargs[:fixed_data_column_widths] = 0
     end
     
     pretty_table(hcat(datavectors...); table_kwargs..., kwargs...)

--- a/src/core.jl
+++ b/src/core.jl
@@ -11,7 +11,7 @@ Base.@kwdef struct PackageState
 end
 
 function Base.:(==)(s1::PackageState, s2::PackageState)
-    s1.dir == s2.dir && 
+    s1.dir == s2.dir &&
     s1.id == s2.id &&
     s1.project == s2.project &&
     s1.load_path == s2.load_path &&
@@ -49,25 +49,18 @@ function printtable(datavectors::Vararg{AbstractVector, N}; kwargs...) where N
         highlighters = [ PrettyTables.TextHighlighter(  (data, i, j) -> (i > 1) && length(unique(data[i,:]))> 1,
                                         crayon"fg:red")]
     end
-    
+
     # Only set fixed column width when showing column labels and multiple columns
     table_kwargs = Dict{Symbol, Any}(
         :row_labels => row_names,
         :auto_wrap => true,
         :line_breaks => true,
         :alignment => :l,
-        :show_column_labels => true,  # Always show column labels for now
-        :highlighters => highlighters
+        :show_column_labels => true,
+        :highlighters => highlighters,
+        :fixed_data_column_widths => min((displaysize(stdout)[2]-19-3*N)÷N,100*N)
     )
-    
-    # Set column width based on number of columns
-    if N > 1
-        table_kwargs[:fixed_data_column_widths] = min((displaysize(stdout)[2]-19-3*N)÷N,100*N)
-    else
-        # For single column, let PrettyTables auto-compute the width
-        table_kwargs[:fixed_data_column_widths] = 0
-    end
-    
+
     pretty_table(hcat(datavectors...); table_kwargs..., kwargs...)
 end
 
@@ -100,7 +93,7 @@ function on_load_package(pkg::Base.PkgId)
     push!(module_states, m => [current_package_state(pkg)])
 end
 
-function idxstates(m::Module, ::Val{i}) where {i} 
+function idxstates(m::Module, ::Val{i}) where {i}
     @assert(i isa Integer, "State index must be an integer or :on_load, :newest, :current")
     return module_states[m][i]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,6 +125,6 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         @test PackageStates.tree_hash_fmt_dir(joinpath(tmp, "link"); use_dir = false) == PackageStates.EMPTY_TREE_HASH
         @test startswith(@capture_err(PackageStates.tree_hash_fmt_dir(joinpath(tmp, "link"); use_dir = false)), "┌ Warning: ")
 
-        @test Set([AnotherDummyPackage, DummyPackage, PackageStates]) ⊂ recorded_modules()
+        @test issubset([AnotherDummyPackage, DummyPackage, PackageStates], recorded_modules())
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,14 +21,14 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
 
 @testset "Basics" begin
     mktempdir() do tmp
-        
+
         env1 = mkdir(joinpath(tmp, "env1"))
         env2 = mkdir(joinpath(tmp, "env2"))
-        
+
         dummy = mkdummypackage(tmp, "DummyPackage")
         dummy2 = mkdummypackage(tmp, "DummyPackage_v2")
         anotherdummy = mkdummypackage(tmp, "AnotherDummyPackage")
-        
+
 
         # Julia on Windows computes a different tree hash before version 1.9.0
         # (after 1.9.0, it is fine for repos, but still differs for bare directories
@@ -40,7 +40,7 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         th_another = th_broken ? "eb224df14392b1d2e12f969907b6404cbd7ab543" : "cc7028d54f62f514daf4b627ad3b60df47ee018b"
         th_another_mod = th_broken ? "a43d3ea9c1d3f6804e709691a4d4317cac3ce5f9" : "3af98e735356d9fb59ccfda8a3264543dd290e1e"
 
-        
+
         Pkg.activate(env1)
         Pkg.add(path=dummy)
         Pkg.activate(env2)
@@ -56,7 +56,7 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         @test s.head_tree_hash == PackageStates.EMPTY_TREE_HASH
         @test s.directory_tree_hash == th1
         @test s.manifest_tree_hash == s.directory_tree_hash
-        
+
         Pkg.activate(env2)
 
         s2 = state(DummyPackage)
@@ -64,7 +64,7 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         @test s2.directory_tree_hash == th1
         @test s2.manifest_tree_hash == th2
         @test s2.load_path[1] == joinpath(env2, "Project.toml")
-        
+
         @test @capture_out(diff_states_all(:on_load => :newest)) == ""
         snew = state(DummyPackage, :newest)
         @test snew.manifest_tree_hash == th1
@@ -72,7 +72,7 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         @test diff_states(DummyPackage, print = false)
         @test @capture_out(diff_states(DummyPackage)) ≠ ""
         @test remove_dateline_from_diff(@capture_out(diff_states(DummyPackage))) == remove_dateline_from_diff(@capture_out(diff_states(DummyPackage, :newest => :current)))
-        
+
         diff_states_all(print = false, update = true)
         supdated = state(DummyPackage, :newest)
         @test supdated.manifest_tree_hash == th2
@@ -125,6 +125,6 @@ remove_dateline_and_header_from_diff(diffstr) = join(split(diffstr, "\n")[union(
         @test PackageStates.tree_hash_fmt_dir(joinpath(tmp, "link"); use_dir = false) == PackageStates.EMPTY_TREE_HASH
         @test startswith(@capture_err(PackageStates.tree_hash_fmt_dir(joinpath(tmp, "link"); use_dir = false)), "┌ Warning: ")
 
-        @test recorded_modules() == Set([AnotherDummyPackage, DummyPackage, PackageStates])
+        @test Set([AnotherDummyPackage, DummyPackage, PackageStates]) ⊂ recorded_modules()
     end
 end


### PR DESCRIPTION
powered by Copilot and Jonas..


This PR does quite a few updates already:
- Updates for PrettyTables v3
- Update CI pipelines
- drop support for julia < v1.10 ( PrettyTables needs 1.10...)

What needs to be done:
Starting julia v1.11 there were some changes on how `__init__()` works. 
It now seems to run at a different time. That means that dependencies of `PackageStates` end up being tracked.
That breaks some of the tests.